### PR TITLE
Teleport theme for Plank for Linux Mint

### DIFF
--- a/Teleport-theme-Mint/dock.theme
+++ b/Teleport-theme-Mint/dock.theme
@@ -1,0 +1,76 @@
+# Teleport Mint Theme for Plank
+#
+#Created: july 2021
+#License: MIT
+#
+#Author: tudo75
+#Social: https://github.com/tudo75
+#
+#Original Author: horberlan
+#Social: https://github.com/horberlan
+#
+
+[PlankTheme]
+#The roundness of the top corners.
+TopRoundness=0
+#The roundness of the bottom corners.
+BottomRoundness=1
+#The thickness (in pixels) of lines drawn.
+LineWidth=2
+#The color (RGBA) of the outer stroke.
+OuterStrokeColor=0;;0;;0;;0
+#The starting color (RGBA) of the fill gradient.
+FillStartColor=0;;0;;0;;0
+#The ending color (RGBA) of the fill gradient.
+FillEndColor=0;;0;;0;;0
+#The color (RGBA) of the inner stroke.
+InnerStrokeColor=146;;182;;98;;1
+
+[PlankDockTheme]
+#The padding on the left/right dock edges, in tenths of a percent of IconSize.
+HorizPadding=12
+#The padding on the top dock edge, in tenths of a percent of IconSize.
+TopPadding=-10
+#The padding on the bottom dock edge, in tenths of a percent of IconSize.
+BottomPadding=0
+#The padding between items on the dock, in tenths of a percent of IconSize.
+ItemPadding=2.5
+#The size of item indicators, in tenths of a percent of IconSize.
+IndicatorSize=8
+#The size of the icon-shadow behind every item, in tenths of a percent of IconSize.
+IconShadowSize=4
+#The height (in percent of IconSize) to bounce an icon when the application sets urgent.
+UrgentBounceHeight=1.75
+#The height (in percent of IconSize) to bounce an icon when launching an application.
+LaunchBounceHeight=0.625
+#The opacity value (0 to 1) to fade the dock to when hiding it.
+FadeOpacity=0
+#The amount of time (in ms) for click animations.
+ClickTime=175
+#The amount of time (in ms) to bounce an urgent icon.
+UrgentBounceTime=600
+#The amount of time (in ms) to bounce an icon when launching an application.
+LaunchBounceTime=600
+#The amount of time (in ms) for active window indicator animations.
+ActiveTime=25
+#The amount of time (in ms) to slide icons into/out of the dock.
+SlideTime=4750
+#The time (in ms) to fade the dock in/out on a hide (if FadeOpacity is < 1).
+FadeTime=350
+#The time (in ms) to slide the dock in/out on a hide (if FadeOpacity is 1).
+HideTime=325
+#The size of the urgent glow (shown when dock is hidden), in tenths of a percent of IconSize.
+GlowSize=30
+#The total time (in ms) to show the hidden-dock urgent glow.
+GlowTime=10000
+#The time (in ms) of each pulse of the hidden-dock urgent glow.
+GlowPulseTime=2750
+#The hue-shift (-180 to 180) of the urgent indicator color.
+UrgentHueShift=175
+#The time (in ms) to move an item to its new position or its addition/removal to/from the dock.
+ItemMoveTime=450
+#Whether background and icons will unhide/hide with different speeds. The top-border of both will leave/hit the screen-edge at the same time.
+CascadeHide=true
+#The color (RGBA) of the badge displaying urgent count
+BadgeColor=0;;0;;0;;0
+


### PR DESCRIPTION
Reduced the gap between icons because too large bar with many icons on bar